### PR TITLE
Update JMeter test and API specification

### DIFF
--- a/bruno-test/translation/body-json-to-xml.bru
+++ b/bruno-test/translation/body-json-to-xml.bru
@@ -17,7 +17,7 @@ headers {
 
 body:json {
   {
-    "text": "Hello, World!"
+    "sentence": "Hello, World!"
   }
 }
 

--- a/bruno-test/translation/translate-to-pig-latin.bru
+++ b/bruno-test/translation/translate-to-pig-latin.bru
@@ -17,16 +17,16 @@ headers {
 
 body:json {
   {
-    "text": "Hello, World!"
+    "sentence": "Hello, World!"
   }
 }
 
 assert {
   res.status: eq 200
   res.body: isJson
-  res.body.text: eq "ellohay, orldway!"
-  res.body.text: isDefined
-  res.body.text: isString
+  res.body.sentence: isDefined
+  res.body.sentence: isString
+  res.body.sentence: eq "ellohay, orldway!"
 }
 
 docs {

--- a/jmeter-test/SmokeTest.jmx
+++ b/jmeter-test/SmokeTest.jmx
@@ -53,6 +53,16 @@
         <boolProp name="ThreadGroup.same_user_on_next_iteration">true</boolProp>
       </ThreadGroup>
       <hashTree>
+        <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Successful" enabled="true">
+          <collectionProp name="Asserion.test_strings">
+            <stringProp name="49586">200</stringProp>
+          </collectionProp>
+          <stringProp name="Assertion.custom_message"></stringProp>
+          <stringProp name="Assertion.test_field">Assertion.response_code</stringProp>
+          <boolProp name="Assertion.assume_success">false</boolProp>
+          <intProp name="Assertion.test_type">8</intProp>
+        </ResponseAssertion>
+        <hashTree/>
         <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="Swagger UI" enabled="true">
           <boolProp name="HTTPSampler.postBodyRaw">false</boolProp>
           <elementProp name="HTTPsampler.Arguments" elementType="Arguments" guiclass="HTTPArgumentsPanel" testclass="Arguments" testname="User Defined Variables" enabled="true">
@@ -72,15 +82,14 @@
           <intProp name="HTTPSampler.ipSourceType">0</intProp>
         </HTTPSamplerProxy>
         <hashTree>
-          <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response Assertion" enabled="true">
-            <collectionProp name="Asserion.test_strings">
-              <stringProp name="49586">200</stringProp>
-            </collectionProp>
-            <stringProp name="Assertion.custom_message"></stringProp>
-            <stringProp name="Assertion.test_field">Assertion.response_code</stringProp>
-            <boolProp name="Assertion.assume_success">false</boolProp>
-            <intProp name="Assertion.test_type">8</intProp>
-          </ResponseAssertion>
+          <HTMLAssertion guiclass="HTMLAssertionGui" testclass="HTMLAssertion" testname="HTML Assertion" enabled="true">
+            <longProp name="html_assertion_error_threshold">0</longProp>
+            <longProp name="html_assertion_warning_threshold">0</longProp>
+            <stringProp name="html_assertion_doctype">auto</stringProp>
+            <boolProp name="html_assertion_errorsonly">true</boolProp>
+            <longProp name="html_assertion_format">0</longProp>
+            <stringProp name="html_assertion_filename">swagger-ui-jtidy.txt</stringProp>
+          </HTMLAssertion>
           <hashTree/>
         </hashTree>
         <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="Translation" enabled="true">
@@ -107,18 +116,8 @@
           <intProp name="HTTPSampler.ipSourceType">0</intProp>
         </HTTPSamplerProxy>
         <hashTree>
-          <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Successful" enabled="true">
-            <collectionProp name="Asserion.test_strings">
-              <stringProp name="49586">200</stringProp>
-            </collectionProp>
-            <stringProp name="Assertion.custom_message"></stringProp>
-            <stringProp name="Assertion.test_field">Assertion.response_code</stringProp>
-            <boolProp name="Assertion.assume_success">false</boolProp>
-            <intProp name="Assertion.test_type">8</intProp>
-          </ResponseAssertion>
-          <hashTree/>
           <JSONPathAssertion guiclass="JSONPathAssertionGui" testclass="JSONPathAssertion" testname="JSON Assertion" enabled="true">
-            <stringProp name="JSON_PATH">$.text</stringProp>
+            <stringProp name="JSON_PATH">$.sentence</stringProp>
             <stringProp name="EXPECTED_VALUE">ellohay, orldway!</stringProp>
             <boolProp name="JSONVALIDATION">true</boolProp>
             <boolProp name="EXPECT_NULL">false</boolProp>
@@ -129,7 +128,7 @@
           <hashTree/>
         </hashTree>
         <UniformRandomTimer guiclass="UniformRandomTimerGui" testclass="UniformRandomTimer" testname="Uniform Random Timer" enabled="true">
-          <stringProp name="ConstantTimer.delay">100</stringProp>
+          <stringProp name="ConstantTimer.delay">500</stringProp>
           <stringProp name="RandomTimer.range">1000</stringProp>
         </UniformRandomTimer>
         <hashTree/>

--- a/src/main/java/lv/id/jc/piglatin/controller/PigLatinController.java
+++ b/src/main/java/lv/id/jc/piglatin/controller/PigLatinController.java
@@ -20,7 +20,7 @@ public class PigLatinController implements PigLatinApi {
 
     @Override
     public ResponseEntity<TranslationResponse> translate(TranslationRequest translationRequest) {
-        var textEnglish = translationRequest.getText();
+        var textEnglish = translationRequest.getSentence();
         var textPigLatin = translationService.translate(textEnglish);
         return new ResponseEntity<>(new TranslationResponse(textPigLatin), HttpStatus.OK);
     }

--- a/src/main/resources/static/openapi.yaml
+++ b/src/main/resources/static/openapi.yaml
@@ -49,11 +49,11 @@ paths:
               $ref: '#/components/schemas/TranslationRequest'
             examples:
               example-1:
-                value: { "text": "Hello world" }
+                value: { "sentence": "Hello world" }
               example-2:
-                value: { "text": "Hello, world!" }
+                value: { "sentence": "Hello, world!" }
               example-3:
-                value: { "text": "Hello, world! How are you?" }
+                value: { "sentence": "Hello, world! How are you?" }
           application/xml:
             schema:
               $ref: '#/components/schemas/TranslationRequest'
@@ -61,17 +61,17 @@ paths:
               example-1:
                 value: |
                   <TranslationRequest>
-                    <text>The quick brown fox jumps over the lazy dog</text>
+                    <sentence>The quick brown fox jumps over the lazy dog</sentence>
                   </TranslationRequest>
               example-2:
                 value: |
                   <TranslationRequest>
-                    <text>Hello, world!</text>
+                    <sentence>Hello, world!</sentence>
                   </TranslationRequest>
               example-3:
                 value: |
                   <TranslationRequest>
-                    <text>Hello, world! How are you?</text>
+                    <sentence>Hello, world! How are you?</sentence>
                   </TranslationRequest>
 
       responses:
@@ -83,11 +83,11 @@ paths:
                 $ref: '#/components/schemas/TranslationResponse'
               examples:
                 example-1:
-                  value: { "text": "Ellohay orldway" }
+                  value: { "sentence": "Ellohay orldway" }
                 example-2:
-                  value: { "text": "Ellohay, orldway!" }
+                  value: { "sentence": "Ellohay, orldway!" }
                 example-3:
-                  value: { "text": "Ellohay, orldway! Owhay areay ouyay?" }
+                  value: { "sentence": "Ellohay, orldway! Owhay areay ouyay?" }
             application/xml:
               schema:
                 $ref: '#/components/schemas/TranslationResponse'
@@ -95,17 +95,17 @@ paths:
                 example-1:
                   value: |
                     <TranslationResponse>
-                      <text>ethay ickquay ownbray oxfay umpsjay overay ethay azylay ogday</text>
+                      <sentence>ethay ickquay ownbray oxfay umpsjay overay ethay azylay ogday</sentence>
                     </TranslationResponse>
                 example-2:
                   value: |
                     <TranslationResponse>
-                      <text>Ellohay, orldway!</text>
+                      <sentence>Ellohay, orldway!</sentence>
                     </TranslationResponse>
                 example-3:
                   value: |
                     <TranslationResponse>
-                      <text>Ellohay, orldway! Owhay areay ouyay?</text>
+                      <sentence>Ellohay, orldway! Owhay areay ouyay?</sentence>
                     </TranslationResponse>
 
         400:
@@ -144,20 +144,25 @@ paths:
 components:
   schemas:
     TranslationRequest:
+      description: |
+        The request body contains the English sentence for translation.
       type: object
-      required: [ text ]
+      required: [ sentence ]
       properties:
-        text:
+        sentence:
           type: string
           format: text
           description: English sentence for translation.
-          example: "Hello world"
+          example: "Hello, world!"
     TranslationResponse:
+      description: |
+        The response body contains the translated sentence in Pig Latin.
+        All punctuation are preserved.
       type: object
-      required: [ text ]
+      required: [ sentence ]
       properties:
-        text:
+        sentence:
           type: string
           format: text
           description: The sentence is translated into Pig Latin.
-          example: "ellohay orldway"
+          example: "ellohay, orldway!"

--- a/src/main/resources/static/rapidoc-basic.html
+++ b/src/main/resources/static/rapidoc-basic.html
@@ -1,0 +1,15 @@
+<!doctype html> <!-- Important: must specify -->
+<html lang="en">
+<head>
+    <title>Pig Latin Translator API</title>
+    <meta charset="utf-8"> <!-- Important: rapi-doc uses utf8 characters -->
+    <script type="module" src="https://unpkg.com/rapidoc/dist/rapidoc-min.js"></script>
+</head>
+<body>
+<rapi-doc
+    spec-url = "openapi.yaml"
+    render-style="view"
+    theme="light"
+> </rapi-doc>
+</body>
+</html>

--- a/src/main/resources/static/rapidoc-font.html
+++ b/src/main/resources/static/rapidoc-font.html
@@ -1,0 +1,28 @@
+<!doctype html> <!-- Important: must specify -->
+<html lang="en">
+<head>
+    <title>Pig Latin Translator API</title>
+    <meta charset="utf-8"> <!-- Important: rapi-doc uses utf8 characters -->
+    <link href="https://fonts.googleapis.com/css?family=Nunito" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css?family=Roboto%20Mono" rel="stylesheet">
+    <script type="module" src="https://unpkg.com/rapidoc/dist/rapidoc-min.js"></script>
+</head>
+<body>
+<rapi-doc
+    spec-url = "openapi.yaml"
+    show-header = "false"
+    render-style = "read"
+    regular-font = "Nunito"
+    mono-font = "Roboto Mono"
+    theme = 'light'
+    bg-color = '#ecf1f7'
+    text-color = '#133863'
+    nav-bg-color = '#3f4d67'
+    nav-text-color = '#a9b7d0'
+    nav-hover-bg-color = '#333f54'
+    nav-hover-text-color = '#fff'
+    nav-accent-color = '#f44236'
+    primary-color = '#5c7096'
+> </rapi-doc>
+</body>
+</html>

--- a/src/main/resources/static/rapidoc-read.html
+++ b/src/main/resources/static/rapidoc-read.html
@@ -1,0 +1,15 @@
+<!doctype html> <!-- Important: must specify -->
+<html lang="en">
+<head>
+    <title>Pig Latin Translator API</title>
+    <meta charset="utf-8"> <!-- Important: rapi-doc uses utf8 characters -->
+    <script type="module" src="https://unpkg.com/rapidoc/dist/rapidoc-min.js"></script>
+</head>
+<body>
+<rapi-doc
+    spec-url="openapi.yaml"
+    render-style="read"
+>
+</rapi-doc>
+</body>
+</html>

--- a/src/main/resources/static/rapidoc.html
+++ b/src/main/resources/static/rapidoc.html
@@ -1,0 +1,11 @@
+<!doctype html> <!-- Important: must specify -->
+<html lang="en">
+<head>
+    <title>Pig Latin Translator API</title>
+    <meta charset="utf-8"> <!-- Important: rapi-doc uses utf8 characters -->
+    <script type="module" src="https://unpkg.com/rapidoc/dist/rapidoc-min.js"></script>
+</head>
+<body>
+<rapi-doc spec-url = "openapi.yaml"> </rapi-doc>
+</body>
+</html>

--- a/src/main/resources/static/redoc.html
+++ b/src/main/resources/static/redoc.html
@@ -1,0 +1,11 @@
+<!doctype html> <!-- Important: must specify -->
+<html lang="en">
+<head>
+    <title>Pig Latin Translator API</title>
+    <meta charset="utf-8">
+</head>
+<body>
+<redoc spec-url="openapi.yaml"></redoc>
+<script src="https://cdn.redoc.ly/redoc/latest/bundles/redoc.standalone.js"> </script>
+</body>
+</html>

--- a/src/rest/body-json-to-xml.http
+++ b/src/rest/body-json-to-xml.http
@@ -5,7 +5,7 @@ Content-Type: application/json
 Accept: application/xml
 
 {
-    "text": "Hello, World!"
+    "sentence": "Hello, World!"
 }
 
 > {%

--- a/src/rest/body-xml-to-xml.http
+++ b/src/rest/body-xml-to-xml.http
@@ -9,7 +9,7 @@ Content-Type: application/xml
 Accept: application/xml
 
 <TranslationRequest>
-    <text>{{text}}</text>
+    <sentence>{{text}}</sentence>
 </TranslationRequest>
 
 > {%

--- a/src/rest/smoke-test.http
+++ b/src/rest/smoke-test.http
@@ -4,7 +4,7 @@ POST {{host}}/pig-latin
 Content-Type: application/json
 
 {
-    "text": "Hello, World!"
+    "sentence": "Hello, World!"
 }
 
 > {%

--- a/src/test/groovy/lv/id/jc/piglatin/controller/PigLatinControllerIT.groovy
+++ b/src/test/groovy/lv/id/jc/piglatin/controller/PigLatinControllerIT.groovy
@@ -23,7 +23,7 @@ class PigLatinControllerIT extends Specification {
         var request = MockMvcRequestBuilders
             .post("/pig-latin")
             .contentType(MediaType.APPLICATION_JSON)
-            .content('{"text":"apple"}')
+            .content('{"sentence":"apple"}')
 
         when:
         def response = mockMvc.perform(request).andReturn().response
@@ -31,7 +31,7 @@ class PigLatinControllerIT extends Specification {
         then:
         with(response) {
             status == 200
-            contentAsString == '{"text":"appleay"}'
+            contentAsString == '{"sentence":"appleay"}'
         }
     }
 
@@ -40,8 +40,8 @@ class PigLatinControllerIT extends Specification {
         mockMvc.perform(MockMvcRequestBuilders
             .post("/pig-latin")
             .contentType(MediaType.APPLICATION_JSON)
-            .content('{"text":""}'))
+            .content('{"sentence":""}'))
             .andExpect(status().isOk())
-            .andExpect(jsonPath('$.text').value(''))
+            .andExpect(jsonPath('$.sentence').value(''))
     }
 }

--- a/src/test/java/piglatin/pig-latin-translator.feature
+++ b/src/test/java/piglatin/pig-latin-translator.feature
@@ -6,32 +6,32 @@ Feature: Pig Latin API
         * path '/pig-latin'
 
     Scenario: Hello World!
-        Given request {"text": "Hello World!"}
+        Given request {"sentence": "Hello World!"}
         When method post
         Then status 200
-        And match response.text == 'ellohay orldway!'
+        And match response.sentence == 'ellohay orldway!'
 
     Scenario: Translate phrase to Pig Latin
         * def sentence =
       """
       {
-        "text": "The quick brown fox jumps over the lazy dog"
+        "sentence": "The quick brown fox jumps over the lazy dog"
       }
       """
 
         Given request sentence
         When method post
         Then status 200
-        * def text = response.text
+        * def text = response.sentence
         And match text == 'ethay ickquay ownbray oxfay umpsjay overay ethay azylay ogday'
 
 
     Scenario Outline: Translate "<text>"
-        * def phrase = { "text": "<text>" }
+        * def phrase = { "sentence": "<text>" }
         Given request phrase
         When method post
         Then status 200
-        * def text = response.text
+        * def text = response.sentence
         And match text == '<pig-latin>'
 
         Examples:


### PR DESCRIPTION
Updated the JMeter test, SmokeTest.jmx, replacing ResponseAssertions with HTMLAssertions and increasing the UniformRandomTimer delay. In the API specification, the 'text' parameter is replaced with 'sentence' for more clarity, and new response body descriptions are added. Also, several new Rapidoc and Redoc HTML files have been added to the resources.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Integrated Rapidoc and Redoc tools for enhanced API documentation.

- **Enhancements**
  - Improved the JMeter test plan with additional assertions and increased delay for more robust testing.
  - Modified JSON and XML keys for better data structure consistency.

- **Bug Fixes**
  - Corrected the method used for retrieving input text in the `PigLatinController`.

- **Documentation**
  - Added new HTML templates for API documentation using Rapidoc and Redoc.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->