### PR TITLE
Create XML to XML, No Body to JSON, and No Body to XML tests

### DIFF
--- a/bruno-test/translation/No Body to JSON.bru
+++ b/bruno-test/translation/No Body to JSON.bru
@@ -1,0 +1,37 @@
+meta {
+  name: No Body to JSON
+  type: http
+  seq: 6
+}
+
+post {
+  url: {{host}}/pig-latin
+  body: none
+  auth: none
+}
+
+headers {
+  Accept: application/json
+  Content-Type: application/json
+}
+
+assert {
+  res.status: eq 400
+  res.body.status: eq 400
+  res.body.error: startsWith Bad Request
+  res.body.sentence: isUndefined
+}
+
+tests {
+  test("should return correct error response", function() {
+    const data = res.getBody();
+    expect(res.getStatus()).to.equal(400);
+    expect(data.status).to.equal(400);
+    expect(data.error).to.equal('Bad Request');
+    expect(data.path).to.equal('/pig-latin');
+  });
+}
+
+docs {
+  Empty payload is sent
+}

--- a/bruno-test/translation/No Body to XML.bru
+++ b/bruno-test/translation/No Body to XML.bru
@@ -15,25 +15,6 @@ headers {
   Accept: application/xml
 }
 
-body:json {
-  {
-    "sentence": "Yellow Submarine"
-  }
-}
-
-body:text {
-  Yellow Submarine
-}
-
-body:xml {
-  <TranslationRequest>
-    <sentence>
-      Yellow Submarine
-    </sentence>
-  </TranslationRequest>
-  
-}
-
 assert {
   res.status: eq 400
   res.body: startsWith <Map>
@@ -41,7 +22,7 @@ assert {
 
 tests {
   const { xml2js } = require('xml2js');
-  
+
   test("should return correct translation", function() {
     xml2js.parseString(res.getBody(), function (err, result) {
       expect(err).to.be.null;
@@ -51,5 +32,5 @@ tests {
 }
 
 docs {
-  Translate English sentence to Pig Latin
+  An error message is expected when sending an empty payload
 }

--- a/bruno-test/translation/No Body to XML.bru
+++ b/bruno-test/translation/No Body to XML.bru
@@ -20,17 +20,6 @@ assert {
   res.body: startsWith <Map>
 }
 
-tests {
-  const { xml2js } = require('xml2js');
-
-  test("should return correct translation", function() {
-    xml2js.parseString(res.getBody(), function (err, result) {
-      expect(err).to.be.null;
-      expect(result.TranslationResponse.sentence[0]).to.equal('ellowyay ubmarinesay');
-    });
-  });
-}
-
 docs {
   An error message is expected when sending an empty payload
 }

--- a/bruno-test/translation/No Body to XML.bru
+++ b/bruno-test/translation/No Body to XML.bru
@@ -1,0 +1,55 @@
+meta {
+  name: No Body to XML
+  type: http
+  seq: 5
+}
+
+post {
+  url: {{host}}/pig-latin
+  body: none
+  auth: none
+}
+
+headers {
+  Content-Type: application/xml
+  Accept: application/xml
+}
+
+body:json {
+  {
+    "sentence": "Yellow Submarine"
+  }
+}
+
+body:text {
+  Yellow Submarine
+}
+
+body:xml {
+  <TranslationRequest>
+    <sentence>
+      Yellow Submarine
+    </sentence>
+  </TranslationRequest>
+  
+}
+
+assert {
+  res.status: eq 400
+  res.body: startsWith <Map>
+}
+
+tests {
+  const { xml2js } = require('xml2js');
+  
+  test("should return correct translation", function() {
+    xml2js.parseString(res.getBody(), function (err, result) {
+      expect(err).to.be.null;
+      expect(result.TranslationResponse.sentence[0]).to.equal('ellowyay ubmarinesay');
+    });
+  });
+}
+
+docs {
+  Translate English sentence to Pig Latin
+}

--- a/bruno-test/translation/XML to XML.bru
+++ b/bruno-test/translation/XML to XML.bru
@@ -1,0 +1,57 @@
+meta {
+  name: XML to XML
+  type: http
+  seq: 4
+}
+
+post {
+  url: {{host}}/pig-latin
+  body: xml
+  auth: none
+}
+
+headers {
+  Content-Type: application/xml
+  Accept: application/xml
+}
+
+body:json {
+  {
+    "sentence": "Yellow Submarine"
+  }
+}
+
+body:text {
+  Yellow Submarine
+}
+
+body:xml {
+  <TranslationRequest>
+    <sentence>
+      Yellow Submarine
+    </sentence>
+  </TranslationRequest>
+  
+}
+
+assert {
+  res.status: eq 200
+  ~res.body: contains ellowyay ubmarinesay
+}
+
+tests {
+  const _ = require('lodash');
+  
+  test("should return correct translation", function() {
+    let body = res.getBody();
+    let sentenceStart = body.indexOf('<sentence>') + 10;
+    let sentenceEnd = body.indexOf('</sentence>');
+    let sentence = _.trim(body.substring(sentenceStart, sentenceEnd));
+    
+    expect(sentence).to.equal('ellowyay ubmarinesay');
+  });
+}
+
+docs {
+  Translate English sentence to Pig Latin
+}

--- a/bruno-test/translation/XML to XML.bru
+++ b/bruno-test/translation/XML to XML.bru
@@ -31,7 +31,7 @@ body:xml {
       Yellow Submarine
     </sentence>
   </TranslationRequest>
-  
+
 }
 
 assert {
@@ -40,15 +40,13 @@ assert {
 }
 
 tests {
-  const _ = require('lodash');
-  
-  test("should return correct translation", function() {
-    let body = res.getBody();
-    let sentenceStart = body.indexOf('<sentence>') + 10;
-    let sentenceEnd = body.indexOf('</sentence>');
-    let sentence = _.trim(body.substring(sentenceStart, sentenceEnd));
-    
-    expect(sentence).to.equal('ellowyay ubmarinesay');
+  const { xml2js } = require('xml2js');
+
+  test("should return error message", function() {
+    xml2js.parseString(res.getBody(), function (err, result) {
+      expect(err).to.be.null;
+      expect(result.TranslationResponse.sentence[0]).to.equal('ellowyay ubmarinesay');
+    });
   });
 }
 


### PR DESCRIPTION
Added three new test files: 'XML to XML.bru', 'No Body to JSON.bru', and 'No Body to XML.bru'. Each file contains a test to check the status response and to validate the translation from English to Pig Latin.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a feature to send HTTP POST requests without a body and validate the response.
  - Added functionality to translate English sentences to Pig Latin via HTTP POST requests with support for JSON, plain text, and XML bodies.
  - Implemented translation of XML content to Pig Latin with comprehensive request and response handling.

- **Documentation**
  - Provided detailed documentation for new translation features and HTTP request behaviors.

- **Tests**
  - Included tests to ensure correct translations and proper response validations for all new features.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->