### PR TITLE
Update API testing frameworks and HTTP test change

### DIFF
--- a/.github/workflows/ijhttp_tests.yaml
+++ b/.github/workflows/ijhttp_tests.yaml
@@ -16,7 +16,7 @@ jobs:
             ijhttp-test/smoke-test.http
             ijhttp-test/body-json-to-json.http
             ijhttp-test/body-text-to-json.http
-            ijhttp-test/body-json-to-xml.http
+            ijhttp-test/body-xml-to-xml.http
             ijhttp-test/api-docs.http
           env_file: ijhttp-test/http-client.env.json
           env: azure

--- a/README.md
+++ b/README.md
@@ -35,7 +35,11 @@ You can use the simple web interface at https://piglatin.azurewebsites.net and t
 
 ## API Testing
 
-The application includes API tests written with two frameworks: Karate and Bruno.
+The application includes API tests written with frameworks:
+- Karate
+- Bruno
+- JetBrains HTTP Client
+- Apache jMeter
 
 ### Bruno
 


### PR DESCRIPTION
README.md has been updated to include JetBrains HTTP Client and Apache jMeter in the API testing frameworks lists. A test in ijhttp_tests.yaml has also been changed from body-json-to-xml.http to body-xml-to-xml.http for better harmonization with the current system.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Updated the automated test suite to include a new XML-focused test.

- **Documentation**
  - Expanded the list of API testing frameworks in the README to include JetBrains HTTP Client and Apache jMeter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->