### PR TITLE
Update tests and remove DESCRIPTION.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,9 @@ https://github.com/rabestro/pig-latin-rest/runs/20211225193
 Successful test report:
 https://github.com/rabestro/pig-latin-rest/runs/20240718373
 
+Failed test report:
+https://github.com/rabestro/pig-latin-rest/runs/20241724987
+
 ### Karate
 
 To run the Karate API tests, use the following command:

--- a/bruno-test/openapi-docs/Confluence.bru
+++ b/bruno-test/openapi-docs/Confluence.bru
@@ -1,0 +1,16 @@
+meta {
+  name: Confluence
+  type: http
+  seq: 5
+}
+
+get {
+  url: https://rabestro.atlassian.net/wiki/spaces/PLT/pages/3768326/API+Documentation+Remote
+  body: none
+  auth: none
+}
+
+assert {
+  res.status: eq 200
+  res.body: contains Atlassian
+}

--- a/bruno-test/openapi-docs/OpenAPI Specification.bru
+++ b/bruno-test/openapi-docs/OpenAPI Specification.bru
@@ -1,0 +1,15 @@
+meta {
+  name: OpenAPI Specification
+  type: http
+  seq: 3
+}
+
+get {
+  url: {{host}}/openapi.yaml
+  body: none
+  auth: none
+}
+
+assert {
+  res.status: eq 200
+}

--- a/bruno-test/openapi-docs/Rapidoc OpenAPI.bru
+++ b/bruno-test/openapi-docs/Rapidoc OpenAPI.bru
@@ -1,0 +1,18 @@
+meta {
+  name: Rapidoc OpenAPI
+  type: http
+  seq: 4
+}
+
+get {
+  url: {{host}}/ui/redoc.html
+  body: none
+  auth: none
+}
+
+assert {
+  res.status: eq 200
+  res.body: contains Pig Latin Translator API
+  res.body: notContains render-style
+  res.body: notContains theme
+}

--- a/bruno-test/openapi-docs/Redoc OpenAPI.bru
+++ b/bruno-test/openapi-docs/Redoc OpenAPI.bru
@@ -1,0 +1,16 @@
+meta {
+  name: Redoc OpenAPI
+  type: http
+  seq: 2
+}
+
+get {
+  url: {{host}}/ui/redoc.html
+  body: none
+  auth: none
+}
+
+assert {
+  res.status: eq 200
+  res.body: contains Pig Latin Translator API
+}

--- a/bruno-test/openapi-docs/Swagger UI.bru
+++ b/bruno-test/openapi-docs/Swagger UI.bru
@@ -1,0 +1,16 @@
+meta {
+  name: Swagger UI
+  type: http
+  seq: 1
+}
+
+get {
+  url: {{host}}/swagger-ui/index.html
+  body: none
+  auth: none
+}
+
+assert {
+  res.status: eq 200
+  res.body: contains Swagger UI
+}

--- a/ijhttp-test/api-docs.http
+++ b/ijhttp-test/api-docs.http
@@ -5,6 +5,12 @@ GET {{host}}/swagger-ui/index.html
 > {% import './scripts/validate-200-response';
 
     client.test("Response body contains 'swagger-ui'", function () {
-        client.assert(response.body.match(/swagger-ui/), "Response doesn't contains 'swagger-ui'");
+        client.assert(response.body.match(/Swagger UI/), "Response doesn't contains 'swagger-ui'");
     });
 %}
+
+### Confluence
+
+GET https://rabestro.atlassian.net/wiki/spaces/PLT/pages/3768326/API+Documentation+Remote
+
+> scripts/validate-200-response.js

--- a/ijhttp-test/bad-request.http
+++ b/ijhttp-test/bad-request.http
@@ -7,10 +7,11 @@ Accept: application/json
 null
 
 > {%
-    import './scripts/validate-200-response';
     import './scripts/validate-content-json';
-
-    client.test("Sentence option exists", function () {
-        client.assert(response.body.hasOwnProperty("sentence"), "Cannot find 'sentence' option in response");
+    client.test("Request returns status 400", function () {
+        client.assert(response.status === 400, `Expected '400' but received '${response.status}'`);
+    });
+    client.test("Error option exists", function () {
+        client.assert(response.body.hasOwnProperty("error"), "Cannot find 'error' option in response");
     });
 %}

--- a/src/main/resources/static/DESCRIPTION.md
+++ b/src/main/resources/static/DESCRIPTION.md
@@ -1,6 +1,0 @@
-Translate text to Pig Latin following the rules:
-
-1. If a word begins with a vowel sound, add an "ay" sound to the end of the word. Please note that "xr" and "yt" at the beginning of a word make vowel sounds (e.g. _"xray"_ -> _"xrayay"_, _"yttria"_ -> _"yttriaay"_).
-2. If a word begins with a consonant sound, move it to the end of the word and then add an "ay" sound to the end of the word. Consonant sounds can be made up of multiple consonants, such as the "ch" in _"chair"_ or "st" in _"stand"_ (e.g. _"chair"_ -> _"airchay"_).
-3. If a word starts with a consonant sound followed by "qu", move it to the end of the word, and then add an "ay" sound to the end of the word (e.g. _"square"_ -> _"aresquay"_).
-4. If a word contains a "y" after a consonant cluster or as the second letter in a two letter word it makes a vowel sound (e.g. _"rhythm"_ -> _"ythmrhay"_, _"my"_ -> _"ymay"_).

--- a/src/test/java/karate-config.js
+++ b/src/test/java/karate-config.js
@@ -4,9 +4,8 @@ function fn() {
     if (!env) {
         env = 'azure';
     }
-    const config = {
-        env: env,
-    }
+    const config = { env }
+
     if (env === 'dev') {
         config.baseUrl = 'http://localhost:8080';
     } else if (env === 'azure') {


### PR DESCRIPTION
Tests in 'ijhttp-test' folder were updated to better validate responses. 'DESCRIPTION.md' file was removed. New test cases under 'bruno-test/openapi-docs' were added to validate OpenAPI documentation pages by performing GET requests and ensuring the responses are successful. The README file was updated with new test report link. A minor change was made in 'karate-config.js'.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated README with a link to the failed test report.

- **New Features**
  - Introduced new API documentation retrieval from Confluence.
  - Added functionality to fetch OpenAPI specifications in YAML format.
  - Configured access to Rapidoc and Redoc OpenAPI documentation UIs.
  - Enhanced Swagger UI accessibility and verification.

- **Bug Fixes**
  - Corrected the assertion for "Swagger UI" in the test script.
  - Updated the bad request test to check for HTTP status code 400 and the presence of an "error" message.

- **Refactor**
  - Streamlined configuration logic in test setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->