### PR TITLE
Update PigLatinController and add new test cases

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -12,7 +12,7 @@ trim_trailing_whitespace = true
 insert_final_newline = true
 indent_size = 4
 
-[*.{yml,yaml,md}]
+[*.{yml,yaml,md,bru}]
 indent_size = 2
 
 [*.java]

--- a/bruno-test/json-response/No Body to JSON.bru
+++ b/bruno-test/json-response/No Body to JSON.bru
@@ -1,7 +1,7 @@
 meta {
   name: No Body to JSON
   type: http
-  seq: 3
+  seq: 5
 }
 
 post {

--- a/bruno-test/json-response/No Body to JSON.bru
+++ b/bruno-test/json-response/No Body to JSON.bru
@@ -19,7 +19,6 @@ assert {
   res.status: eq 400
   res.body.status: eq 400
   res.body.error: startsWith Bad Request
-  res.body.sentence: isUndefined
 }
 
 tests {

--- a/bruno-test/json-response/Null request sent.bru
+++ b/bruno-test/json-response/Null request sent.bru
@@ -1,7 +1,7 @@
 meta {
-  name: Bad Request (Null)
+  name: Null request sent
   type: http
-  seq: 2
+  seq: 4
 }
 
 post {

--- a/bruno-test/json-response/Null sentence sent.bru
+++ b/bruno-test/json-response/Null sentence sent.bru
@@ -18,5 +18,7 @@ body:json {
 
 assert {
   res.status: eq 400
-  res.body: isJson 
+  res.body: isJson
+  res.body.error: isDefined
+  res.body.error: contains Bad Request
 }

--- a/bruno-test/json-response/Null sentence sent.bru
+++ b/bruno-test/json-response/Null sentence sent.bru
@@ -1,0 +1,22 @@
+meta {
+  name: Null sentence sent
+  type: http
+  seq: 3
+}
+
+post {
+  url: {{host}}/pig-latin
+  body: json
+  auth: none
+}
+
+body:json {
+  {
+    "sentence": null
+  }
+}
+
+assert {
+  res.status: eq 400
+  res.body: isJson 
+}

--- a/bruno-test/json-response/Sentence can't be translated.bru
+++ b/bruno-test/json-response/Sentence can't be translated.bru
@@ -1,0 +1,22 @@
+meta {
+  name: Sentence can't be translated
+  type: http
+  seq: 2
+}
+
+post {
+  url: {{host}}/pig-latin
+  body: json
+  auth: none
+}
+
+body:json {
+  {
+    "sentence": "$#±@%&!"
+  }
+}
+
+assert {
+  res.status: eq 418
+  res.body: isEmpty
+}

--- a/bruno-test/json-response/Translate sentence to Pig Latin.bru
+++ b/bruno-test/json-response/Translate sentence to Pig Latin.bru
@@ -1,5 +1,5 @@
 meta {
-  name: Translate text to Pig Latin
+  name: Translate sentence to Pig Latin
   type: http
   seq: 1
 }

--- a/pom.xml
+++ b/pom.xml
@@ -394,7 +394,16 @@
                     <artifactId>maven-changelog-plugin</artifactId>
                     <version>2.3</version>
                 </plugin>
-
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-site-plugin</artifactId>
+                    <version>4.0.0-M13</version>
+                </plugin>
+                <plugin>
+                    <groupId>com.github.eirslett</groupId>
+                    <artifactId>frontend-maven-plugin</artifactId>
+                    <version>1.15.0</version>
+                </plugin>
                 <plugin>
                     <groupId>org.openapitools</groupId>
                     <artifactId>openapi-generator-maven-plugin</artifactId>

--- a/src/main/java/lv/id/jc/piglatin/controller/PigLatinController.java
+++ b/src/main/java/lv/id/jc/piglatin/controller/PigLatinController.java
@@ -1,13 +1,14 @@
 package lv.id.jc.piglatin.controller;
 
 
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RestController;
+
 import lv.id.jc.piglatin.api.PigLatinApi;
 import lv.id.jc.piglatin.model.TranslationRequest;
 import lv.id.jc.piglatin.model.TranslationResponse;
 import lv.id.jc.piglatin.service.TranslationService;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.RestController;
 
 /**
  * PigLatinController handles translation requests for translating English sentences to Pig Latin.
@@ -25,6 +26,9 @@ public class PigLatinController implements PigLatinApi {
     public ResponseEntity<TranslationResponse> translate(TranslationRequest translationRequest) {
         var textEnglish = translationRequest.getSentence();
         var textPigLatin = translationService.translate(textEnglish);
+        if (textPigLatin.equalsIgnoreCase(textEnglish)) {
+            return new ResponseEntity<>(HttpStatus.I_AM_A_TEAPOT);
+        }
         return new ResponseEntity<>(new TranslationResponse(textPigLatin), HttpStatus.OK);
     }
 }

--- a/src/main/resources/static/openapi.yaml
+++ b/src/main/resources/static/openapi.yaml
@@ -2,7 +2,7 @@ openapi: 3.1.0
 info:
   title: Pig Latin translator
   summary: Translate text to Pig Latin
-  description:
+  description: |
     Pig Latin is a made-up children's language that's intended to be confusing.
     It obeys a few simple rules (below), but when it's spoken quickly it's really difficult for non-children (and non-native speakers) to understand.
 
@@ -78,7 +78,7 @@ paths:
                   </TranslationRequest>
 
       responses:
-        200:
+        '200':
           description: English sentence successfully translated into Pig Latin.
           content:
             application/json:
@@ -111,7 +111,7 @@ paths:
                       <sentence>Ellohay, orldway! Owhay areay ouyay?</sentence>
                     </TranslationResponse>
 
-        400:
+        '400':
           description: |
             The request body is invalid. The response body contains the error message.
           content:
@@ -143,6 +143,10 @@ paths:
               examples:
                 example-1:
                   value: { "timestamp": "2021-08-15T12:34:56.789Z", "status": 400, "error": "Bad Request", "path": "/pig-latin" }
+
+        '418':
+          description: This cannot be translated into Pig Latin...
+          content: {}
 
 components:
   schemas:

--- a/src/test/groovy/lv/id/jc/piglatin/controller/PigLatinControllerIT.groovy
+++ b/src/test/groovy/lv/id/jc/piglatin/controller/PigLatinControllerIT.groovy
@@ -3,13 +3,12 @@ package lv.id.jc.piglatin.controller
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
 import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers
 import spock.lang.Specification
-
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 
 @SpringBootTest
 @AutoConfigureMockMvc
@@ -30,18 +29,25 @@ class PigLatinControllerIT extends Specification {
 
         then:
         with(response) {
-            status == 200
+            status == HttpStatus.OK.value()
             contentAsString == '{"sentence":"appleay"}'
         }
     }
 
-    def "translate method with empty text"() {
-        expect:
-        mockMvc.perform(MockMvcRequestBuilders
+    def "can't translate '#untranslatableExpression'"() {
+        given:
+        def payload = '{"sentence":"' + untranslatableExpression + '"}'
+
+        when:
+        def result = mockMvc.perform(MockMvcRequestBuilders
             .post("/pig-latin")
             .contentType(MediaType.APPLICATION_JSON)
-            .content('{"sentence":""}'))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath('$.sentence').value(''))
+            .content(payload))
+
+        then:
+        result.andExpect(MockMvcResultMatchers.status().isIAmATeapot())
+
+        where:
+        untranslatableExpression << ['', '   ', '4572', '%$#@&']
     }
 }

--- a/src/test/groovy/lv/id/jc/piglatin/controller/PigLatinControllerSpec.groovy
+++ b/src/test/groovy/lv/id/jc/piglatin/controller/PigLatinControllerSpec.groovy
@@ -29,18 +29,16 @@ class PigLatinControllerSpec extends Specification {
         result.body == response
     }
 
-    def "translate method with empty text"() {
+    def "can't translate empty text"() {
         given:
         def request = new TranslationRequest('')
-        def response = new TranslationResponse('')
         translationService.translate('') >> ''
 
         when:
         ResponseEntity<TranslationResponse> result = controller.translate(request)
 
         then:
-        result.statusCode == HttpStatus.OK
-        result.body == response
+        result.statusCode == HttpStatus.I_AM_A_TEAPOT
     }
 
     def "translate method when TranslationService throws exception"() {


### PR DESCRIPTION
Updated the PigLatinController to handle cases where the translation doesn't change the sentence. Added the logic to return a specific HTTP status for such situations. Also, introduced new Bruno test cases for different input scenarios including null and untranslatable sentences. Updated pom.xml and openAPI documentation accordingly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced the "No Body to JSON" operation with updated sequence numbering.
	- Improved user feedback by renaming the "Bad Request (Null)" to "Null request sent" with adjusted sequence tracking.
	- Introduced a new check for sending null sentences with proper error handling.
	- Added functionality to handle translations of sentences into Pig Latin with appropriate error responses.

- **Bug Fixes**
	- Updated the naming in the metadata to accurately reflect the "Translate sentence to Pig Latin" feature.

- **Refactor**
	- Optimized imports and added logical checks in the Pig Latin translation controller for better performance and accuracy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->