### PR TITLE
Update README with deployment details and links

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,11 @@ This will start the application on localhost:8080. You can access the Swagger UI
 
 ## Deployed Application
 
-The application is deployed on Azure at the following URL: https://piglatin.azurewebsites.net.
+The application is deployed on Azure at https://piglatin.azurewebsites.net.
 
-You can use the simple web interface at https://piglatin.azurewebsites.net and the Swagger UI at https://piglatin.azurewebsites.net/swagger-ui/index.html.
+You can use the simple [web interface](https://piglatin.azurewebsites.net) and the [Swagger UI](https://piglatin.azurewebsites.net/swagger-ui/index.html).
+
+Please note that the application is deployed on the free-tier F1 plan. This means that if the application is in sleep mode, it may take about a minute for the first API call to wake it up. Subsequent API calls should be faster.
 
 ## API Testing
 
@@ -56,7 +58,7 @@ https://github.com/rabestro/pig-latin-rest/runs/20240100050
 Failed test report:
 https://github.com/rabestro/pig-latin-rest/runs/20211225193
 
-> [!NOTE]  
+> [!NOTE]
 > Note - Bruno's script support might also be used for light test automation based on project specifics.
 
 ### JetBrains HTTP Client

--- a/jmeter-test/PerformanceTest.jmx
+++ b/jmeter-test/PerformanceTest.jmx
@@ -92,21 +92,40 @@
             <boolProp name="ISREGEX">false</boolProp>
           </JSONPathAssertion>
           <hashTree/>
-          <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response Assertion" enabled="true">
-            <collectionProp name="Asserion.test_strings">
-              <stringProp name="49586">200</stringProp>
-            </collectionProp>
-            <stringProp name="Assertion.custom_message"></stringProp>
-            <stringProp name="Assertion.test_field">Assertion.response_code</stringProp>
-            <boolProp name="Assertion.assume_success">false</boolProp>
-            <intProp name="Assertion.test_type">8</intProp>
-          </ResponseAssertion>
-          <hashTree/>
         </hashTree>
+        <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="Swagger HTTP Request" enabled="true">
+          <boolProp name="HTTPSampler.postBodyRaw">false</boolProp>
+          <elementProp name="HTTPsampler.Arguments" elementType="Arguments" guiclass="HTTPArgumentsPanel" testclass="Arguments" testname="User Defined Variables" enabled="true">
+            <collectionProp name="Arguments.arguments"/>
+          </elementProp>
+          <stringProp name="HTTPSampler.path">/swagger-ui/index.html</stringProp>
+          <stringProp name="HTTPSampler.method">GET</stringProp>
+          <boolProp name="HTTPSampler.follow_redirects">true</boolProp>
+          <boolProp name="HTTPSampler.auto_redirects">false</boolProp>
+          <boolProp name="HTTPSampler.use_keepalive">true</boolProp>
+          <boolProp name="HTTPSampler.DO_MULTIPART_POST">false</boolProp>
+          <boolProp name="HTTPSampler.BROWSER_COMPATIBLE_MULTIPART">false</boolProp>
+          <boolProp name="HTTPSampler.image_parser">false</boolProp>
+          <boolProp name="HTTPSampler.concurrentDwn">false</boolProp>
+          <stringProp name="HTTPSampler.concurrentPool">6</stringProp>
+          <boolProp name="HTTPSampler.md5">false</boolProp>
+          <intProp name="HTTPSampler.ipSourceType">0</intProp>
+        </HTTPSamplerProxy>
+        <hashTree/>
         <UniformRandomTimer guiclass="UniformRandomTimerGui" testclass="UniformRandomTimer" testname="Uniform Random Timer" enabled="false">
           <stringProp name="ConstantTimer.delay">100</stringProp>
           <stringProp name="RandomTimer.range">500</stringProp>
         </UniformRandomTimer>
+        <hashTree/>
+        <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response Assertion" enabled="true">
+          <collectionProp name="Asserion.test_strings">
+            <stringProp name="49586">200</stringProp>
+          </collectionProp>
+          <stringProp name="Assertion.custom_message"></stringProp>
+          <stringProp name="Assertion.test_field">Assertion.response_code</stringProp>
+          <boolProp name="Assertion.assume_success">false</boolProp>
+          <intProp name="Assertion.test_type">8</intProp>
+        </ResponseAssertion>
         <hashTree/>
       </hashTree>
       <ThreadGroup guiclass="ThreadGroupGui" testclass="ThreadGroup" testname="Thread Group" enabled="false">


### PR DESCRIPTION
Updated README to include deployment details about the Azure free-tier F1 plan. Also, added hyperlinks for easier access to the web interface and Swagger UI. The note about potential delays during the first API call due to sleep mode of the free-tier plan was added as well.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated application deployment URLs and added deployment plan notes.
	- Updated notes on using test automation scripts.

- **Refactor**
	- Improved performance testing by adjusting HTTP requests and response handling.

- **Tests**
	- Enhanced test automation with new sampler and timer configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->