### PR TITLE
Add Spring Boot Actuator and associated endpoints

### DIFF
--- a/bruno-test/actuator/Health.bru
+++ b/bruno-test/actuator/Health.bru
@@ -1,0 +1,15 @@
+meta {
+  name: Server Health
+  type: http
+  seq: 1
+}
+
+get {
+  url: {{host}}/actuator/health
+  body: none
+  auth: none
+}
+
+assert {
+  res.body.status: eq UP
+}

--- a/ijhttp-test/actuator.http
+++ b/ijhttp-test/actuator.http
@@ -1,0 +1,11 @@
+### Actuator Main
+GET {{host}}/actuator
+
+### Actuator Health
+GET {{host}}/actuator/health
+
+### Actuator Beans
+GET {{host}}/actuator/beans
+
+### Actuator Info
+GET {{host}}/actuator/info

--- a/pom.xml
+++ b/pom.xml
@@ -181,6 +181,10 @@
             <groupId>com.fasterxml.jackson.dataformat</groupId>
             <artifactId>jackson-dataformat-xml</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+        </dependency>
 
         <!-- SpringDoc OpenAPI dependencies -->
         <dependency>

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -7,3 +7,9 @@ server:
 springdoc:
   swagger-ui:
     url: /openapi.yaml
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: '*'


### PR DESCRIPTION
In this update, Spring Boot Actuator has been added via the pom.xml. Management endpoints in the application YAML have been exposed and two new test files have been created to check the status of Actuator and server health. This provides better monitoring and management capabilities for the application.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a server health check endpoint.
	- Provided new test functions for actuator endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->