### PR TITLE
Add translation counter to Pig Latin Translation Service

### DIFF
--- a/bruno-test/actuator/Reset Translation Counter.bru
+++ b/bruno-test/actuator/Reset Translation Counter.bru
@@ -1,0 +1,15 @@
+meta {
+  name: Reset Translation Counter
+  type: http
+  seq: 5
+}
+
+delete {
+  url: {{host}}/actuator/translationcount
+  body: none
+  auth: none
+}
+
+assert {
+  res.status: eq 204
+}

--- a/bruno-test/actuator/Show Translation Counter.bru
+++ b/bruno-test/actuator/Show Translation Counter.bru
@@ -1,0 +1,17 @@
+meta {
+  name: Show Translation Counter
+  type: http
+  seq: 4
+}
+
+get {
+  url: {{host}}/actuator/translationcount
+  body: none
+  auth: none
+}
+
+assert {
+  res.status: eq 200
+  res.body.count: isNumber
+  res.body.count: gte 0
+}

--- a/bruno-test/scenario/translation-counter/Check Translation Counter.bru
+++ b/bruno-test/scenario/translation-counter/Check Translation Counter.bru
@@ -1,0 +1,17 @@
+meta {
+  name: Check Translation Counter
+  type: http
+  seq: 4
+}
+
+get {
+  url: {{host}}/actuator/translationcount
+  body: none
+  auth: none
+}
+
+assert {
+  res.status: eq 200
+  res.body.count: isNumber
+  res.body.count: eq 1
+}

--- a/bruno-test/scenario/translation-counter/Reset Translation Counter.bru
+++ b/bruno-test/scenario/translation-counter/Reset Translation Counter.bru
@@ -1,0 +1,15 @@
+meta {
+  name: Reset Translation Counter
+  type: http
+  seq: 1
+}
+
+delete {
+  url: {{host}}/actuator/translationcount
+  body: none
+  auth: none
+}
+
+assert {
+  res.status: eq 204
+}

--- a/bruno-test/scenario/translation-counter/Second Check.bru
+++ b/bruno-test/scenario/translation-counter/Second Check.bru
@@ -1,0 +1,16 @@
+meta {
+  name: Second Check
+  type: http
+  seq: 6
+}
+
+get {
+  url: {{host}}/actuator/translationcount
+  body: none
+  auth: none
+}
+
+assert {
+  res.status: eq 200
+  res.body.count: eq 2
+}

--- a/bruno-test/scenario/translation-counter/Set Translation Counter.bru
+++ b/bruno-test/scenario/translation-counter/Set Translation Counter.bru
@@ -1,0 +1,22 @@
+meta {
+  name: Set Translation Counter
+  type: http
+  seq: 7
+}
+
+post {
+  url: {{host}}/actuator/translationcount
+  body: json
+  auth: none
+}
+
+body:json {
+  {
+    "count": 9
+  }
+}
+
+assert {
+  res.status: eq 200
+  res.body.count: eq 9
+}

--- a/bruno-test/scenario/translation-counter/Translate first sentence.bru
+++ b/bruno-test/scenario/translation-counter/Translate first sentence.bru
@@ -1,0 +1,34 @@
+meta {
+  name: Translate first sentence
+  type: http
+  seq: 3
+}
+
+post {
+  url: {{host}}/pig-latin
+  body: json
+  auth: none
+}
+
+headers {
+  Content-Type: application/json
+  Accept: application/json
+}
+
+body:json {
+  {
+    "sentence": "Hello, World!"
+  }
+}
+
+assert {
+  res.status: eq 200
+  res.body: isJson
+  res.body.sentence: isDefined
+  res.body.sentence: isString
+  res.body.sentence: eq "ellohay, orldway!"
+}
+
+docs {
+  Translate English sentence to Pig Latin
+}

--- a/bruno-test/scenario/translation-counter/Translate second sentence.bru
+++ b/bruno-test/scenario/translation-counter/Translate second sentence.bru
@@ -1,0 +1,32 @@
+meta {
+  name: Translate second sentence
+  type: http
+  seq: 5
+}
+
+post {
+  url: {{host}}/pig-latin
+  body: json
+  auth: none
+}
+
+headers {
+  Content-Type: application/json
+  Accept: application/json
+}
+
+body:json {
+  {
+    "sentence": "The quick brown fox jumps over the lazy dog."
+  }
+}
+
+assert {
+  res.status: eq 200
+  res.body.sentence: isString
+  res.body.sentence: eq ethay ickquay ownbray oxfay umpsjay overay ethay azylay ogday.
+}
+
+docs {
+  Translate English sentence to Pig Latin
+}

--- a/bruno-test/scenario/translation-counter/Validate Translation Counter.bru
+++ b/bruno-test/scenario/translation-counter/Validate Translation Counter.bru
@@ -1,0 +1,16 @@
+meta {
+  name: Validate Translation Counter
+  type: http
+  seq: 8
+}
+
+get {
+  url: {{host}}/actuator/translationcount
+  body: none
+  auth: none
+}
+
+assert {
+  res.status: eq 200
+  res.body.count: eq 9
+}

--- a/bruno-test/scenario/translation-counter/Zero Translation Counter.bru
+++ b/bruno-test/scenario/translation-counter/Zero Translation Counter.bru
@@ -1,0 +1,17 @@
+meta {
+  name: Zero Translation Counter
+  type: http
+  seq: 2
+}
+
+get {
+  url: {{host}}/actuator/translationcount
+  body: none
+  auth: none
+}
+
+assert {
+  res.status: eq 200
+  res.body.count: isNumber
+  res.body.count: gte 0
+}

--- a/src/main/java/lv/id/jc/piglatin/PigLatinRestApplication.java
+++ b/src/main/java/lv/id/jc/piglatin/PigLatinRestApplication.java
@@ -2,11 +2,25 @@ package lv.id.jc.piglatin;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Bean;
+
+import java.net.http.HttpClient;
+import java.util.concurrent.atomic.AtomicInteger;
 
 @SpringBootApplication
 public class PigLatinRestApplication {
 
     public static void main(String[] args) {
         SpringApplication.run(PigLatinRestApplication.class, args);
+    }
+
+    @Bean
+    public HttpClient httpClient() {
+        return HttpClient.newHttpClient();
+    }
+
+    @Bean
+    public AtomicInteger translationCounter() {
+        return new AtomicInteger(0);
     }
 }

--- a/src/main/java/lv/id/jc/piglatin/actuator/BlogHealthIndicator.java
+++ b/src/main/java/lv/id/jc/piglatin/actuator/BlogHealthIndicator.java
@@ -16,10 +16,6 @@ public class BlogHealthIndicator implements HealthIndicator {
     private final IntFunction<Health> healthFunction;
     private final IntSupplier statusCodeSupplier;
 
-    public BlogHealthIndicator() {
-        this(new StatusCodeSupplier(), new HealthFunction());
-    }
-
     public BlogHealthIndicator(IntSupplier statusCodeSupplier, IntFunction<Health> healthFunction) {
         this.healthFunction = healthFunction;
         this.statusCodeSupplier = statusCodeSupplier;

--- a/src/main/java/lv/id/jc/piglatin/actuator/HealthFunction.java
+++ b/src/main/java/lv/id/jc/piglatin/actuator/HealthFunction.java
@@ -4,12 +4,14 @@ import java.util.function.IntFunction;
 
 import org.springframework.boot.actuate.health.Health;
 import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Component;
 
 /**
  * The HealthFunction class is an implementation of the IntFunction functional interface.
  * It is responsible for converting an HTTP status code into a Health object that represents the health of a service.
  */
-class HealthFunction implements IntFunction<Health> {
+@Component
+public class HealthFunction implements IntFunction<Health> {
     /**
      * Converts an HTTP status code into a Health object that represents the health of a service.
      *

--- a/src/main/java/lv/id/jc/piglatin/actuator/StatusCodeSupplier.java
+++ b/src/main/java/lv/id/jc/piglatin/actuator/StatusCodeSupplier.java
@@ -1,5 +1,7 @@
 package lv.id.jc.piglatin.actuator;
 
+import org.springframework.stereotype.Component;
+
 import java.io.IOException;
 import java.net.URI;
 import java.net.http.HttpClient;
@@ -12,15 +14,12 @@ import java.util.function.IntSupplier;
  * This class is an implementation of the IntSupplier interface. It supplies an HTTP response code
  * by making a GET request to a specified base URL using an instance of HttpClient.
  */
-class StatusCodeSupplier implements IntSupplier {
+@Component
+public class StatusCodeSupplier implements IntSupplier {
     private static final String BASE_URL = "https://jc.id.lv/";
     private final HttpClient httpClient;
 
-    StatusCodeSupplier() {
-        this(HttpClient.newHttpClient());
-    }
-
-    StatusCodeSupplier(HttpClient httpClient) {
+    public StatusCodeSupplier(HttpClient httpClient) {
         this.httpClient = httpClient;
     }
 

--- a/src/main/java/lv/id/jc/piglatin/actuator/TranslationCountEndpoint.java
+++ b/src/main/java/lv/id/jc/piglatin/actuator/TranslationCountEndpoint.java
@@ -1,0 +1,39 @@
+package lv.id.jc.piglatin.actuator;
+
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.actuate.endpoint.annotation.DeleteOperation;
+import org.springframework.boot.actuate.endpoint.annotation.Endpoint;
+import org.springframework.boot.actuate.endpoint.annotation.ReadOperation;
+import org.springframework.boot.actuate.endpoint.annotation.WriteOperation;
+import org.springframework.stereotype.Component;
+
+
+@Component
+@Endpoint(id = "translationcount")
+public class TranslationCountEndpoint {
+
+    private final AtomicInteger counterService;
+
+    public TranslationCountEndpoint(@Qualifier("translationCounter") AtomicInteger counterService) {
+        this.counterService = counterService;
+    }
+
+    @ReadOperation
+    public Map<String, Integer> count() {
+        return Map.of("count", counterService.get());
+    }
+
+    @WriteOperation
+    public Map<String, Integer> set(int count) {
+        counterService.set(count);
+        return count();
+    }
+
+    @DeleteOperation
+    public void reset() {
+        counterService.set(0);
+    }
+}

--- a/src/main/java/lv/id/jc/piglatin/service/TranslationService.java
+++ b/src/main/java/lv/id/jc/piglatin/service/TranslationService.java
@@ -1,6 +1,7 @@
 package lv.id.jc.piglatin.service;
 
 import java.util.Locale;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.UnaryOperator;
 
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -11,13 +12,20 @@ import org.springframework.stereotype.Service;
  */
 @Service
 public class TranslationService {
-    private final UnaryOperator<String> translator;
 
-    public TranslationService(@Qualifier("phraseTranslator") UnaryOperator<String> translator) {
+    private final UnaryOperator<String> translator;
+    private final AtomicInteger translationCounter;
+
+    public TranslationService(
+        @Qualifier("phraseTranslator") UnaryOperator<String> translator,
+        @Qualifier("translationCounter") AtomicInteger translationCounter
+    ) {
         this.translator = translator;
+        this.translationCounter = translationCounter;
     }
 
     public String translate(String text) {
+        translationCounter.incrementAndGet();
         return translator.apply(text.toLowerCase(Locale.ROOT));
     }
 }

--- a/src/test/groovy/lv/id/jc/piglatin/service/TranslationCountEndpointSpec.groovy
+++ b/src/test/groovy/lv/id/jc/piglatin/service/TranslationCountEndpointSpec.groovy
@@ -1,0 +1,51 @@
+package lv.id.jc.piglatin.service
+
+import lv.id.jc.piglatin.actuator.TranslationCountEndpoint
+import spock.lang.Specification
+import spock.lang.Subject
+
+import java.util.concurrent.atomic.AtomicInteger
+
+class TranslationCountEndpointSpec extends Specification {
+
+    def counterService = new AtomicInteger(0)
+
+    @Subject
+    def endpoint = new TranslationCountEndpoint(counterService)
+
+    def "should return count"() {
+        given:
+        counterService.set(1)
+
+        when:
+        def result = endpoint.count()
+
+        then:
+        result == [count: 1]
+    }
+
+    def "should set count"() {
+        given:
+        counterService.set(0)
+
+        when:
+        def result = endpoint.set(2)
+
+        then:
+        counterService.get() == 2
+
+        and:
+        result == [count: 2]
+    }
+
+    def "should reset count"() {
+        given:
+        counterService.set(9)
+
+        when:
+        endpoint.reset()
+
+        then:
+        counterService.get() == 0
+    }
+}


### PR DESCRIPTION
Translation counter feature has been added to keep track of the number of translations made by the Pig Latin Translation service. This was achieved by introducing new scenario files to handle the count check, increment, reset, and set operations. The translation counter was integrated into the TranslationService, incrementing for each translation request. Additionally, actuator endpoints were created for accessing and manipulating the translation counter. A TranslationCountEndpoint class was also added to handle these operations. Tests were written to validate this new feature.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a feature to reset the translation counter.
	- Added the ability to retrieve and display the current translation count.
	- Implemented functionality to set a specific translation count.
	- Provided a translation service to convert English sentences to Pig Latin.

- **Enhancements**
	- Improved health check mechanisms with new constructor parameters for better customization.

- **Documentation**
	- Added documentation for translating English sentences to Pig Latin.

- **Testing**
	- Created tests to verify translation count retrieval, setting, and reset functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->