### PR TITLE
Update actuator endpoint naming

### DIFF
--- a/bruno/scenario/translation-counter/Check Translation Counter.bru
+++ b/bruno/scenario/translation-counter/Check Translation Counter.bru
@@ -5,7 +5,7 @@ meta {
 }
 
 get {
-  url: {{host}}/actuator/translationcount
+  url: {{host}}/actuator/translation-count
   body: none
   auth: none
 }

--- a/bruno/scenario/translation-counter/Reset Translation Counter.bru
+++ b/bruno/scenario/translation-counter/Reset Translation Counter.bru
@@ -5,7 +5,7 @@ meta {
 }
 
 delete {
-  url: {{host}}/actuator/translationcount
+  url: {{host}}/actuator/translation-count
   body: none
   auth: none
 }

--- a/bruno/scenario/translation-counter/Second Check.bru
+++ b/bruno/scenario/translation-counter/Second Check.bru
@@ -5,7 +5,7 @@ meta {
 }
 
 get {
-  url: {{host}}/actuator/translationcount
+  url: {{host}}/actuator/translation-count
   body: none
   auth: none
 }

--- a/bruno/scenario/translation-counter/Set Translation Counter.bru
+++ b/bruno/scenario/translation-counter/Set Translation Counter.bru
@@ -5,7 +5,7 @@ meta {
 }
 
 post {
-  url: {{host}}/actuator/translationcount
+  url: {{host}}/actuator/translation-count
   body: json
   auth: none
 }

--- a/bruno/scenario/translation-counter/Validate Translation Counter.bru
+++ b/bruno/scenario/translation-counter/Validate Translation Counter.bru
@@ -5,7 +5,7 @@ meta {
 }
 
 get {
-  url: {{host}}/actuator/translationcount
+  url: {{host}}/actuator/translation-count
   body: none
   auth: none
 }

--- a/bruno/scenario/translation-counter/Zero Translation Counter.bru
+++ b/bruno/scenario/translation-counter/Zero Translation Counter.bru
@@ -5,7 +5,7 @@ meta {
 }
 
 get {
-  url: {{host}}/actuator/translationcount
+  url: {{host}}/actuator/translation-count
   body: none
   auth: none
 }

--- a/http-yac/actuator/reset-translation-counter.http
+++ b/http-yac/actuator/reset-translation-counter.http
@@ -1,3 +1,3 @@
-DELETE {{host}}/actuator/translationcount
+DELETE {{host}}/actuator/translation-count
 
 ?? status == 204

--- a/http-yac/actuator/show-translation-counter.http
+++ b/http-yac/actuator/show-translation-counter.http
@@ -1,5 +1,5 @@
 # @disabled
-{{host}}/actuator/translationcount
+{{host}}/actuator/translation-count
 
 ?? status == 200
 ?? body count isNumber


### PR DESCRIPTION
The actuator endpoint 'translationcount' has been updated to 'translation-count' across multiple files. This change improves readability and follows the standard kebab-case naming convention for URLs. All associated URLs in the Bruno and HTTP-YAC scenarios have been updated accordingly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Updated the endpoint URL for translation counter related actions from `/actuator/translationcount` to `/actuator/translation-count` across various scenarios and HTTP configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->