### PR TITLE
Add counter increment and update conditions in HTTP requests

### DIFF
--- a/http-client/poc/increase-counter.http
+++ b/http-client/poc/increase-counter.http
@@ -1,0 +1,17 @@
+@sut = actuator/translation-count
+
+### Read Translation Counter
+GET {{host}}/{{sut}}
+
+> {%
+    const counter = parseInt(response.body.count + 5).toString();
+    client.global.set('counter', counter);
+%}
+
+### Set Translation Counter
+POST {{host}}/{{sut}}
+Content-Type: application/json
+
+{
+    "count": {{counter}}
+}

--- a/http-yac/actuator/health.http
+++ b/http-yac/actuator/health.http
@@ -1,8 +1,7 @@
-# @disabled
 GET {{host}}/actuator/health
 
 ?? status == 200
 ?? body status == UP
 ?? body components.diskSpace.status == UP
-?? body components.diskSpace.details.total > 0
-?? body components.diskSpace.details.free > 0
+?? body components.diskSpace.details.total > 1
+?? body components.diskSpace.details.free > 1

--- a/http-yac/actuator/server-info.http
+++ b/http-yac/actuator/server-info.http
@@ -8,6 +8,6 @@
 ?? body os exists
 ?? body java exists
 ?? body java.version startsWith 17
-?? body app.source-code endsWith pig-latin-rest
-?? body app.source-code contains rabestro
+?? body app["source-code"] endsWith pig-latin-rest
+?? body app["source-code"] contains rabestro
 ?? body os.name == Linux

--- a/http-yac/actuator/show-translation-counter.http
+++ b/http-yac/actuator/show-translation-counter.http
@@ -1,6 +1,5 @@
-# @disabled
 {{host}}/actuator/translation-count
 
 ?? status == 200
 ?? body count isNumber
-?? body count >= 0
+?? body count > -1

--- a/http-yac/poc/increase-counter.http
+++ b/http-yac/poc/increase-counter.http
@@ -1,0 +1,17 @@
+@sut = actuator/translation-count
+
+### Read Translation Counter
+# @name translationCounter
+GET {{host}}/{{sut}}
+
+{{
+    translationCounter.count += 5
+}}
+
+### Set Translation Counter
+# @ref translationCounter
+
+POST {{host}}/{{sut}}
+Content-Type: application/json
+
+{{translationCounter}}


### PR DESCRIPTION
New code is introduced to increment a translation counter in the system. Two `increase-counter.http` files have been created under 'http-client/poc' and 'http-yac/poc' respectively. Moreover, conditions related to disk space, source code, and count checks in several 'http-yac/actuator' files have been adjusted to a stricter or more accurate value. This aims to improve the robustness of the HTTP endpoint tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a feature to read and increment a translation counter by 5.

- **Bug Fixes**
	- Adjusted disk space health check to expect values greater than 1.
	- Updated access method for a key in the `app` object to enhance compatibility.
	- Improved validation for translation count response to include -1 as a valid count.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->