### PR TITLE
Add API tests using Hurl

### DIFF
--- a/.github/workflows/api-tests-http-yac.yaml
+++ b/.github/workflows/api-tests-http-yac.yaml
@@ -1,5 +1,3 @@
-# This workflow runs the API tests on the latest version of Ubuntu
-
 name: API Tests - httpYac
 
 on:

--- a/.github/workflows/api-tests-hurl.yaml
+++ b/.github/workflows/api-tests-hurl.yaml
@@ -1,0 +1,27 @@
+name: API Tests - hurl
+
+on:
+  workflow_dispatch:
+permissions:
+  contents: read
+  actions: read
+  checks: write
+jobs:
+  install-hurl:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: gacts/install-hurl@v1
+      - name: Install hurl and run tests
+        run: |
+          hurl --test \
+          --variable host=https://piglatin.azurewebsites.net \
+          --report-junit report.xml \
+          ./hurl/translation-counter.hurl
+
+      - name: Publish Test Report
+        uses: dorny/test-reporter@v1
+        if: success() || failure()
+        with:
+          name: hurl API Tests
+          path: report.xml
+          reporter: java-junit

--- a/hurl/RunTest.ps1
+++ b/hurl/RunTest.ps1
@@ -1,0 +1,4 @@
+hurl `
+    --test `
+    --variable host=https://piglatin.azurewebsites.net `
+    ./translation-counter.hurl

--- a/hurl/translation-counter.hurl
+++ b/hurl/translation-counter.hurl
@@ -1,0 +1,64 @@
+# Reset Translation Counter
+DELETE {{host}}/actuator/translation-count
+HTTP 204
+
+# Zero Translation Counter
+GET {{host}}/actuator/translation-count
+HTTP 200
+[Asserts]
+header "Content-Type" contains "json"
+jsonpath "$.count" == 0
+
+# Translate first sentence
+POST {{host}}/pig-latin
+Content-Type: application/json
+
+{
+    "sentence": "Hello, World!"
+}
+
+HTTP 200
+Content-Type: application/json
+[Asserts]
+jsonpath "$.sentence" == "ellohay, orldway!"
+
+# Check Translation Counter
+GET {{host}}/actuator/translation-count
+HTTP 200
+[Asserts]
+jsonpath "$.count" == 1
+
+# Translate second sentence
+POST {{host}}/pig-latin
+Content-Type: application/json
+
+{
+    "sentence": "The quick brown fox jumps over the lazy dog."
+}
+
+HTTP 200
+Content-Type: application/json
+[Asserts]
+jsonpath "$.sentence" == "ethay ickquay ownbray oxfay umpsjay overay ethay azylay ogday."
+
+# Second Counter Check
+GET {{host}}/actuator/translation-count
+HTTP 200
+[Asserts]
+jsonpath "$.count" == 2
+
+# Set Translation Counter
+POST {{host}}/actuator/translation-count
+Content-Type: application/json
+
+{"count": 9}
+
+HTTP 200
+[Asserts]
+jsonpath "$.count" == 9
+
+# Check Changed Counter
+GET {{host}}/actuator/translation-count
+HTTP 200
+[Asserts]
+jsonpath "$.count" == 9


### PR DESCRIPTION
This commit adds a new workflow for API tests using Hurl and creates new Hurl scripts for testing. Minor changes have also been made to the existing httpYac tests, such as the removal of explanatory comments.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Removed outdated comments about workflow environments.
- **New Features**
	- Introduced a new workflow for running API tests with the `hurl` tool.
	- Added a script for executing Hurl tests, enhancing testing capabilities.
	- Implemented a new set of API requests focused on managing a translation counter, including functionality for resetting, incrementing, and setting specific count values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->