### PR TITLE
Refactor endpoint and application configuration

### DIFF
--- a/bruno/actuator/Reset Translation Counter.bru
+++ b/bruno/actuator/Reset Translation Counter.bru
@@ -5,7 +5,7 @@ meta {
 }
 
 delete {
-  url: {{host}}/actuator/translation-count
+  url: {{host}}/actuator/count
   body: none
   auth: none
 }

--- a/bruno/actuator/Show Translation Counter.bru
+++ b/bruno/actuator/Show Translation Counter.bru
@@ -5,7 +5,7 @@ meta {
 }
 
 get {
-  url: {{host}}/actuator/translation-count
+  url: {{host}}/actuator/count
   body: none
   auth: none
 }

--- a/bruno/scenario/translation-counter/Check Translation Counter.bru
+++ b/bruno/scenario/translation-counter/Check Translation Counter.bru
@@ -5,7 +5,7 @@ meta {
 }
 
 get {
-  url: {{host}}/actuator/translation-count
+  url: {{host}}/actuator/count
   body: none
   auth: none
 }

--- a/bruno/scenario/translation-counter/Reset Translation Counter.bru
+++ b/bruno/scenario/translation-counter/Reset Translation Counter.bru
@@ -5,7 +5,7 @@ meta {
 }
 
 delete {
-  url: {{host}}/actuator/translation-count
+  url: {{host}}/actuator/count
   body: none
   auth: none
 }

--- a/bruno/scenario/translation-counter/Second Check.bru
+++ b/bruno/scenario/translation-counter/Second Check.bru
@@ -5,7 +5,7 @@ meta {
 }
 
 get {
-  url: {{host}}/actuator/translation-count
+  url: {{host}}/actuator/count
   body: none
   auth: none
 }

--- a/bruno/scenario/translation-counter/Set Translation Counter.bru
+++ b/bruno/scenario/translation-counter/Set Translation Counter.bru
@@ -5,7 +5,7 @@ meta {
 }
 
 post {
-  url: {{host}}/actuator/translation-count
+  url: {{host}}/actuator/count
   body: json
   auth: none
 }

--- a/bruno/scenario/translation-counter/Validate Translation Counter.bru
+++ b/bruno/scenario/translation-counter/Validate Translation Counter.bru
@@ -5,7 +5,7 @@ meta {
 }
 
 get {
-  url: {{host}}/actuator/translation-count
+  url: {{host}}/actuator/count
   body: none
   auth: none
 }

--- a/bruno/scenario/translation-counter/Zero Translation Counter.bru
+++ b/bruno/scenario/translation-counter/Zero Translation Counter.bru
@@ -5,7 +5,7 @@ meta {
 }
 
 get {
-  url: {{host}}/actuator/translation-count
+  url: {{host}}/actuator/count
   body: none
   auth: none
 }

--- a/http-client/poc/increase-counter.http
+++ b/http-client/poc/increase-counter.http
@@ -1,4 +1,4 @@
-@sut = actuator/translation-count
+@sut = actuator/count
 
 ### Read Translation Counter
 GET {{host}}/{{sut}}

--- a/http-client/scenario/translation-counter.http
+++ b/http-client/scenario/translation-counter.http
@@ -3,13 +3,15 @@
 ### Reset Translation Counter
 DELETE {{host}}/{{sut}}
 
-?? status == 204
+> {%
+    client.test("Request executed successfully", function () {
+        client.assert(response.status === 204, `Expected '204' but received '${response.status}'`);
+    });
+%}
 
 ### Zero Translation Counter
 GET {{host}}/{{sut}}
 
-?? status == 200
-?? body count == 0
 
 ### Translate first sentence
 POST {{host}}/pig-latin
@@ -19,15 +21,10 @@ Content-Type: application/json
     "sentence": "Hello, World!"
 }
 
-?? status == 200
-?? header content-type == application/json
-?? body sentence == ellohay, orldway!
 
 ### Check Translation Counter
 GET {{host}}/{{sut}}
 
-?? status == 200
-?? body count == 1
 
 ### Translate second sentence
 POST {{host}}/pig-latin
@@ -37,27 +34,17 @@ Content-Type: application/json
     "sentence": "The quick brown fox jumps over the lazy dog."
 }
 
-?? status == 200
-?? header content-type == application/json
-?? body sentence == ethay ickquay ownbray oxfay umpsjay overay ethay azylay ogday.
-
 ### Second Counter Check
 GET {{host}}/{{sut}}
 
-?? status == 200
-?? body count == 2
 
 ### Set Translation Counter
 POST {{host}}/{{sut}}
 Content-Type: application/json
 
-{"count": 9}
-
-?? status == 200
-?? body count == 9
+{
+    "count": 9
+}
 
 ### Check Changed Counter
 GET {{host}}/{{sut}}
-
-?? status == 200
-?? body count == 9

--- a/hurl/translation-counter.hurl
+++ b/hurl/translation-counter.hurl
@@ -1,9 +1,9 @@
 # Reset Translation Counter
-DELETE {{host}}/actuator/translation-count
+DELETE {{host}}/actuator/count
 HTTP 204
 
 # Zero Translation Counter
-GET {{host}}/actuator/translation-count
+GET {{host}}/actuator/count
 HTTP 200
 [Asserts]
 header "Content-Type" contains "json"

--- a/hurl/translation-counter.hurl
+++ b/hurl/translation-counter.hurl
@@ -23,7 +23,7 @@ Content-Type: application/json
 jsonpath "$.sentence" == "ellohay, orldway!"
 
 # Check Translation Counter
-GET {{host}}/actuator/translation-count
+GET {{host}}/actuator/count
 HTTP 200
 [Asserts]
 jsonpath "$.count" == 1
@@ -42,13 +42,13 @@ Content-Type: application/json
 jsonpath "$.sentence" == "ethay ickquay ownbray oxfay umpsjay overay ethay azylay ogday."
 
 # Second Counter Check
-GET {{host}}/actuator/translation-count
+GET {{host}}/actuator/count
 HTTP 200
 [Asserts]
 jsonpath "$.count" == 2
 
 # Set Translation Counter
-POST {{host}}/actuator/translation-count
+POST {{host}}/actuator/count
 Content-Type: application/json
 
 {"count": 9}
@@ -58,7 +58,7 @@ HTTP 200
 jsonpath "$.count" == 9
 
 # Check Changed Counter
-GET {{host}}/actuator/translation-count
+GET {{host}}/actuator/count
 HTTP 200
 [Asserts]
 jsonpath "$.count" == 9

--- a/src/main/java/lv/id/jc/piglatin/actuator/StatusCodeSupplier.java
+++ b/src/main/java/lv/id/jc/piglatin/actuator/StatusCodeSupplier.java
@@ -15,7 +15,7 @@ import org.springframework.stereotype.Component;
 public class StatusCodeSupplier implements IntSupplier {
     private final HttpClient httpClient;
 
-    @Value("${my-blog.url:'https://jc.id.lv'}")
+    @Value("${blog.url:'https://jc.id.lv'}")
     private String blogUrl;
 
     public StatusCodeSupplier(HttpClient httpClient) {

--- a/src/main/java/lv/id/jc/piglatin/actuator/TranslationCountEndpoint.java
+++ b/src/main/java/lv/id/jc/piglatin/actuator/TranslationCountEndpoint.java
@@ -15,7 +15,7 @@ import org.springframework.stereotype.Component;
  * It provides methods for reading, setting, and resetting the translation count.
  */
 @Component
-@Endpoint(id = "translation-count")
+@Endpoint(id = "count")
 public class TranslationCountEndpoint {
 
     private final AtomicInteger counterService;

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -43,5 +43,5 @@ info:
     version: @project.version@
     java-version: @java.version@
 
-my-blog:
+blog:
   url: https://jc.id.lv


### PR DESCRIPTION
Endpoint id for translation count has been changed from 'translation-count' to 'count', improving simplicity and standardizing endpoint naming across different services. Also, the configuration property 'my-blog.url' has been refactored to 'blog.url' thus standardizing the naming convention for application configuration properties.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new scenario for testing translation counter functionality.
- **Refactor**
	- Updated URL paths for translation counter operations from `/actuator/translation-count` to `/actuator/count`.
	- Renamed the translation counter endpoint ID for clarity and consistency.
- **Chores**
	- Updated the default value for a property in the system configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->