### PR TITLE
Update endpoint id from 'count' to 'counter'

### DIFF
--- a/bruno/actuator/Reset Translation Counter.bru
+++ b/bruno/actuator/Reset Translation Counter.bru
@@ -5,7 +5,7 @@ meta {
 }
 
 delete {
-  url: {{host}}/actuator/count
+  url: {{host}}/actuator/counter
   body: none
   auth: none
 }

--- a/bruno/actuator/Show Translation Counter.bru
+++ b/bruno/actuator/Show Translation Counter.bru
@@ -5,7 +5,7 @@ meta {
 }
 
 get {
-  url: {{host}}/actuator/count
+  url: {{host}}/actuator/counter
   body: none
   auth: none
 }

--- a/bruno/scenario/translation-counter/Check Translation Counter.bru
+++ b/bruno/scenario/translation-counter/Check Translation Counter.bru
@@ -5,7 +5,7 @@ meta {
 }
 
 get {
-  url: {{host}}/actuator/count
+  url: {{host}}/actuator/counter
   body: none
   auth: none
 }

--- a/bruno/scenario/translation-counter/Reset Translation Counter.bru
+++ b/bruno/scenario/translation-counter/Reset Translation Counter.bru
@@ -5,7 +5,7 @@ meta {
 }
 
 delete {
-  url: {{host}}/actuator/count
+  url: {{host}}/actuator/counter
   body: none
   auth: none
 }

--- a/bruno/scenario/translation-counter/Second Check.bru
+++ b/bruno/scenario/translation-counter/Second Check.bru
@@ -5,7 +5,7 @@ meta {
 }
 
 get {
-  url: {{host}}/actuator/count
+  url: {{host}}/actuator/counter
   body: none
   auth: none
 }

--- a/bruno/scenario/translation-counter/Set Translation Counter.bru
+++ b/bruno/scenario/translation-counter/Set Translation Counter.bru
@@ -5,7 +5,7 @@ meta {
 }
 
 post {
-  url: {{host}}/actuator/count
+  url: {{host}}/actuator/counter
   body: json
   auth: none
 }

--- a/bruno/scenario/translation-counter/Validate Translation Counter.bru
+++ b/bruno/scenario/translation-counter/Validate Translation Counter.bru
@@ -5,7 +5,7 @@ meta {
 }
 
 get {
-  url: {{host}}/actuator/count
+  url: {{host}}/actuator/counter
   body: none
   auth: none
 }

--- a/bruno/scenario/translation-counter/Zero Translation Counter.bru
+++ b/bruno/scenario/translation-counter/Zero Translation Counter.bru
@@ -5,7 +5,7 @@ meta {
 }
 
 get {
-  url: {{host}}/actuator/count
+  url: {{host}}/actuator/counter
   body: none
   auth: none
 }

--- a/http-client/poc/increase-counter.http
+++ b/http-client/poc/increase-counter.http
@@ -1,4 +1,4 @@
-@sut = actuator/count
+@sut = actuator/counter
 
 ### Read Translation Counter
 GET {{host}}/{{sut}}

--- a/http-client/scenario/translation-counter.http
+++ b/http-client/scenario/translation-counter.http
@@ -1,4 +1,4 @@
-@sut = actuator/count
+@sut = actuator/counter
 
 ### Reset Translation Counter
 DELETE {{host}}/{{sut}}

--- a/http-yac/actuator/reset-translation-counter.http
+++ b/http-yac/actuator/reset-translation-counter.http
@@ -1,3 +1,3 @@
-DELETE {{host}}/actuator/translation-count
+DELETE {{host}}/actuator/counter
 
 ?? status == 204

--- a/http-yac/actuator/show-translation-counter.http
+++ b/http-yac/actuator/show-translation-counter.http
@@ -1,4 +1,4 @@
-{{host}}/actuator/translation-count
+{{host}}/actuator/counter
 
 ?? status == 200
 ?? body count isNumber

--- a/http-yac/poc/increase-counter.http
+++ b/http-yac/poc/increase-counter.http
@@ -1,4 +1,4 @@
-@sut = actuator/translation-count
+@sut = actuator/counter
 
 ### Read Translation Counter
 # @name translationCounter

--- a/http-yac/scenario/translation-counter.http
+++ b/http-yac/scenario/translation-counter.http
@@ -1,4 +1,4 @@
-@sut = actuator/count
+@sut = actuator/counter
 
 ### Reset Translation Counter
 DELETE {{host}}/{{sut}}

--- a/hurl/translation-counter.hurl
+++ b/hurl/translation-counter.hurl
@@ -1,9 +1,9 @@
 # Reset Translation Counter
-DELETE {{host}}/actuator/count
+DELETE {{host}}/actuator/counter
 HTTP 204
 
 # Zero Translation Counter
-GET {{host}}/actuator/count
+GET {{host}}/actuator/counter
 HTTP 200
 [Asserts]
 header "Content-Type" contains "json"
@@ -23,7 +23,7 @@ Content-Type: application/json
 jsonpath "$.sentence" == "ellohay, orldway!"
 
 # Check Translation Counter
-GET {{host}}/actuator/count
+GET {{host}}/actuator/counter
 HTTP 200
 [Asserts]
 jsonpath "$.count" == 1
@@ -42,13 +42,13 @@ Content-Type: application/json
 jsonpath "$.sentence" == "ethay ickquay ownbray oxfay umpsjay overay ethay azylay ogday."
 
 # Second Counter Check
-GET {{host}}/actuator/count
+GET {{host}}/actuator/counter
 HTTP 200
 [Asserts]
 jsonpath "$.count" == 2
 
 # Set Translation Counter
-POST {{host}}/actuator/count
+POST {{host}}/actuator/counter
 Content-Type: application/json
 
 {"count": 9}
@@ -58,7 +58,7 @@ HTTP 200
 jsonpath "$.count" == 9
 
 # Check Changed Counter
-GET {{host}}/actuator/count
+GET {{host}}/actuator/counter
 HTTP 200
 [Asserts]
 jsonpath "$.count" == 9

--- a/pom.xml
+++ b/pom.xml
@@ -89,7 +89,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <groovy.version>4.0.18</groovy.version>
+        <groovy.version>4.0.20</groovy.version>
 
         <swagger-api.version>2.2.20</swagger-api.version>
         <swagger-ui.version>5.10.3</swagger-ui.version>
@@ -536,38 +536,6 @@
             </plugin>
             <plugin>
                 <artifactId>maven-failsafe-plugin</artifactId>
-            </plugin>
-
-            <plugin>
-                <groupId>com.lazerycode.jmeter</groupId>
-                <artifactId>jmeter-maven-plugin</artifactId>
-                <executions>
-                    <!-- Generate JMeter configuration -->
-                    <execution>
-                        <id>configuration</id>
-                        <goals>
-                            <goal>configure</goal>
-                        </goals>
-                    </execution>
-                    <!-- Run JMeter tests -->
-                    <execution>
-                        <id>jmeter-tests</id>
-                        <goals>
-                            <goal>jmeter</goal>
-                        </goals>
-                    </execution>
-                    <!-- Fail build on errors in test -->
-                    <execution>
-                        <id>jmeter-check-results</id>
-                        <goals>
-                            <goal>results</goal>
-                        </goals>
-                    </execution>
-                </executions>
-                <configuration>
-                    <generateReports>true</generateReports>
-                    <jmeterVersion>5.6.3</jmeterVersion>
-                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/src/main/java/lv/id/jc/piglatin/actuator/TranslationCountEndpoint.java
+++ b/src/main/java/lv/id/jc/piglatin/actuator/TranslationCountEndpoint.java
@@ -15,7 +15,7 @@ import org.springframework.stereotype.Component;
  * It provides methods for reading, setting, and resetting the translation count.
  */
 @Component
-@Endpoint(id = "count")
+@Endpoint(id = "counter")
 public class TranslationCountEndpoint {
 
     private final AtomicInteger counterService;


### PR DESCRIPTION
The 'count' endpoint id was updated to 'counter' across the application. This change has been applied across all instances in the HTTP calls and in the TranslationCountEndpoint class. The pom.xml file also got updated by increasing the groovy version and removing the jmeter-maven-plugin configuration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Updated URL/endpoint for translation counter functionalities across various scenarios and requests to `/actuator/counter`.
- **Bug Fixes**
	- Corrected the endpoint in the `translation-counter.hurl` file for DELETE, GET, and POST requests to ensure consistency with the updated endpoint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->